### PR TITLE
Ajustando detalles de la expensa de usuario

### DIFF
--- a/back/src/modules/payments/payments.service.ts
+++ b/back/src/modules/payments/payments.service.ts
@@ -112,27 +112,12 @@ export class PaymentsService {
 
     const savedPayment = await this.paymentsRepository.createPayment(payment);
 
-    const functional_units_expenses: FunctionalUnitExpense[] =
-      await this.functionalUnitExpenseRepository.find({
-        where: {
-          functional_unit: {
-            id: functionalUnitExpense.functional_unit.id,
-          },
-        },
-      });
-
     if (payment.amount >= functionalUnitExpense.functional_unit.balance) {
-      for (const fue of functional_units_expenses) {
-        if (fue.payment_status === PAYMENT_STATUS.PAID) continue;
-        fue.payment_status = PAYMENT_STATUS.PAID;
-        await this.functionalUnitExpenseRepository.save(fue);
-      }
+      functionalUnitExpense.payment_status = PAYMENT_STATUS.PAID;
+      await this.functionalUnitExpenseRepository.save(functionalUnitExpense);
     } else {
-      for (const fue of functional_units_expenses) {
-        if (fue.payment_status === PAYMENT_STATUS.PAID) continue;
-        fue.payment_status = PAYMENT_STATUS.PARTIAL;
-        await this.functionalUnitExpenseRepository.save(fue);
-      }
+      functionalUnitExpense.payment_status = PAYMENT_STATUS.PARTIAL;
+      await this.functionalUnitExpenseRepository.save(functionalUnitExpense);
     }
     const functional_unit = functionalUnitExpense.functional_unit;
     functional_unit.balance = functional_unit.balance - payment.amount;

--- a/front/src/app/dashboard/usuario/expenses/[id]/page.tsx
+++ b/front/src/app/dashboard/usuario/expenses/[id]/page.tsx
@@ -67,11 +67,6 @@ const ExpensesUnitId = () => {
     return (
         <ContainerDashboard className="w-[90%] h-[90vh]">
             <Title>Pagar expensa</Title>
-            <div className="w-[90%] flex justify-end my-2 mt-0">
-                <Link href="/dashboard/usuario/expenses">
-                    <Button className="w-32 py-2 rounded-[40px]">Volver</Button>
-                </Link>
-            </div>
             <div className="w-full h-[50%] border rounded-[40px] flex flex-col items-center justify-center p-3">
                 <div className="font-bold text-2xl my-3">Resumen</div>
                 <div className="flex flex-col border w-[50%] p-5 gap-2 rounded-[40px] px-10">

--- a/front/src/app/dashboard/usuario/expenses/page.tsx
+++ b/front/src/app/dashboard/usuario/expenses/page.tsx
@@ -43,7 +43,7 @@ const Expenses = () => {
     const [selectetUF, setSelectetUF] = useState<string>("");
     const { haveUF, isLoading, functional_unit } = useUfSesion();
     const router = useRouter();
-    console.log(functionalUnit);
+
     useEffect(() => {
         if (!isLoading && !haveUF) {
             router.push("/dashboard/usuario/addfuncionalunit");
@@ -70,45 +70,27 @@ const Expenses = () => {
     }, [token, path]);
 
     useEffect(() => {
-        const fechtExpenses = async () => {
-            if (!selectetUF) {
-                return; // No hacer la solicitud si no hay unidad funcional seleccionada
-            }
+        const fetchData = async () => {
+            if (!selectetUF) return;
             try {
-                const response = await functionalUnitExpensesId(
-                    fUnitExpenses[0].id,
-                    token
-                );
-                if (response) {
-                    setExpenses(response);
-                } else {
-                    Swal.fire({
-                        title: "Error",
-                        text: "Error al obtener la unidad funcional",
-                        icon: "error",
-                        showConfirmButton: false,
-                        timer: 1500,
-                    });
-                }
-            } catch (error) {
-                console.error(error);
-            }
-        };
-        if (token && selectetUF !== "") {
-            fechtExpenses();
-        }
-    }, [token, selectetUF]);
-
-    useEffect(() => {
-        const fechtExpenses = async () => {
-            if (!selectetUF) {
-                return;
-            }
-            try {
-                const response = await expensesIdFu(selectetUF, token);
-                if (response) {
-                    console.log(response);
-                    setfUnitExpenses(response);
+                const responseExpenses = await expensesIdFu(selectetUF, token);
+                if (responseExpenses) {
+                    setfUnitExpenses(responseExpenses);
+                    const firstExpenseId = responseExpenses[0]?.id;
+                    if (firstExpenseId) {
+                        const responseDetails = await functionalUnitExpensesId(firstExpenseId, token);
+                        if (responseDetails) {
+                            setExpenses(responseDetails);
+                        } else {
+                            Swal.fire({
+                                title: "Error",
+                                text: "Error al obtener la unidad funcional",
+                                icon: "error",
+                                showConfirmButton: false,
+                                timer: 1500,
+                            });
+                        }
+                    }
                 } else {
                     Swal.fire({
                         title: "Error",
@@ -123,11 +105,11 @@ const Expenses = () => {
             }
         };
         if (token && selectetUF !== "") {
-            fechtExpenses();
+            fetchData();
         }
     }, [selectetUF, token]);
-
-    console.log(fUnitExpenses);
+    
+    
     const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const { value } = e.target;
 
@@ -162,18 +144,24 @@ const Expenses = () => {
                         </p>
                         <p className="flex items-center justify-center w-full h-1/4 text-2xl">
                             $
-                            {expenses != undefined ? fUnitExpenses[0].total_amount : 0}
+                            {expenses != undefined ? fUnitExpenses[0]?.functional_unit?.balance : 0}
                         </p>
-                        <Link
-                            href={`/dashboard/usuario/expenses/${fUnitExpenses[0]?.id}`}
-                        >
-                            <Button
-                                className="w-32 rounded-[40px]"
-                                disabled={expenses == undefined}
-                            >
-                                Pagar
-                            </Button>
-                        </Link>
+                        {fUnitExpenses.length > 0 && (
+                            fUnitExpenses[0]?.functional_unit?.balance > 0 ? (
+                                <Link href={`/dashboard/usuario/expenses/${fUnitExpenses[0]?.id}`}>
+                                    <Button className="w-32 rounded-[40px]">
+                                        Pagar
+                                    </Button>
+                                </Link>
+                            ) : (
+                                <Button
+                                    className="w-32 rounded-[40px] bg-gray-400 cursor-not-allowed"
+                                    disabled
+                                >
+                                    Pagar
+                                </Button>
+                            )
+                        )}
                     </div>
                 </div>
                 <div className="flex items-center justify-center w-1/2 h-full border rounded-[40px] gap-2 bg-gradient-to-r from-neutral-50 via-fondo to-fondo">

--- a/front/src/app/dashboard/usuario/expenses/page.tsx
+++ b/front/src/app/dashboard/usuario/expenses/page.tsx
@@ -150,7 +150,7 @@ const Expenses = () => {
                                 </Link>
                             ) : (
                                 <Button
-                                    className="w-24 py-2 rounded-[40px] bg-gray-400 cursor-not-allowed"
+                                    className="w-24 py-2 rounded-[40px] opacity-50 cursor-not-allowed"
                                     disabled
                                 >
                                     Pagar
@@ -176,7 +176,7 @@ const Expenses = () => {
                   name="id"
                   id="id"
                 >
-                  <option value="">Selecciona tu unidad Funcional</option>
+                  <option value="" disabled>Selecciona tu unidad Funcional</option>
                   {functionalUnit?.map((unit) => (
                     <option value={unit.id} key={unit.id}>
                       {unit.location}


### PR DESCRIPTION
- Actualización de cambio de estado del pago: sólo se actualiza el estado de la última functional_unit_expense.
- Corrección de error al seleccionar por primera vez la unidad funcional.
- Deshabilitación de link/botón Pagar con balance de unidad funcional <= 0
- Eliminación de botón Volver en vista de pago de expensa